### PR TITLE
Support UnicodeSyntax type signatures

### DIFF
--- a/haskell-edit.el
+++ b/haskell-edit.el
@@ -34,7 +34,7 @@
 (defun haskell-find-type-signature (&optional pos)
   (save-excursion
     (if pos (goto-char pos))
-    (re-search-backward "::" nil t)
+    (re-search-backward "\\(::\\|∷\\)" nil t)
     (skip-chars-backward " ")
     (let ((end (point)) beg token)
       (backward-word)


### PR DESCRIPTION
This will make `haskell-find-type-signature` work correctly in case you ever run into code using `∷` for type signatures with the `UnicodeSyntax` extension.

I don't know how many people actually use that, but I've been using it for my slides and might start using it in my open source code too :).